### PR TITLE
TypeError: (new Date(...)).toLocaleFormat is not a function

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,26 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install, build, and test
+      run: |
+        npm install
+        npm run build --if-present
+        npm test
+      env:
+        CI: true


### PR DESCRIPTION
The settings of extension datetime-format@Daniel-Khodabakhsh.github.com had an error:
```
TypeError: (new Date(...)).toLocaleFormat is not a function
```

Stack trace:
```
dateTimeFormat@/home/wqhj/.local/share/gnome-shell/extensions/datetime-format@Daniel-Khodabakhsh.github.com/Utilities.js:15:85
updatePreview@/home/wqhj/.local/share/gnome-shell/extensions/datetime-format@Daniel-Khodabakhsh.github.com/FormatTarget.js:49:25
create@/home/wqhj/.local/share/gnome-shell/extensions/datetime-format@Daniel-Khodabakhsh.github.com/FormatTarget.js:55:2
buildPrefsWidget/<@/home/wqhj/.local/share/gnome-shell/extensions/datetime-format@Daniel-Khodabakhsh.github.com/prefs.js:136:61
buildPrefsWidget@/home/wqhj/.local/share/gnome-shell/extensions/datetime-format@Daniel-Khodabakhsh.github.com/prefs.js:136:2
_selectExtension@resource:///org/gnome/shell/extensionPrefs/main.js:75:22
_onCommandLine@resource:///org/gnome/shell/extensionPrefs/main.js:320:17
main@resource:///org/gnome/shell/extensionPrefs/main.js:635:5
@<main>:1:43
```
